### PR TITLE
Allow providing precision range

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -32,7 +32,7 @@ export interface NumberInputOptions {
   hidePrefixOrSuffixOnFocus?: boolean
   hideGroupingSeparatorOnFocus?: boolean
   hideNegligibleDecimalDigitsOnFocus?: boolean
-  precision?: number
+  precision?: number | NumberRange
   autoDecimalDigits?: boolean
   autoSign?: boolean
   valueRange?: NumberRange

--- a/src/numberFormat.ts
+++ b/src/numberFormat.ts
@@ -36,8 +36,11 @@ export class NumberFormat {
 
     if (this.decimalSymbol === undefined) {
       this.minimumFractionDigits = this.maximumFractionDigits = 0
-    } else if (precision !== undefined) {
+    } else if (typeof precision === 'number') {
       this.minimumFractionDigits = this.maximumFractionDigits = precision
+    } else if (typeof precision === 'object') {
+      this.minimumFractionDigits = precision.min || 0
+      this.maximumFractionDigits = precision.max !== undefined ? precision.max : 15
     } else {
       const { maximumFractionDigits, minimumFractionDigits } = new Intl.NumberFormat(locale, { currency, unit, style }).resolvedOptions()
       this.minimumFractionDigits = minimumFractionDigits

--- a/tests/unit/numberFormat.spec.ts
+++ b/tests/unit/numberFormat.spec.ts
@@ -123,6 +123,10 @@ describe('NumberFormat', () => {
           expect(new NumberFormat({ formatStyle: NumberFormatStyle.Currency, currency: 'EUR', precision: 0 })).toEqual(
             expect.objectContaining({ minimumFractionDigits: 0, maximumFractionDigits: 0 })
           )
+
+          expect(new NumberFormat({ formatStyle: NumberFormatStyle.Currency, currency: 'EUR', precision: { min: 2, max: 5 } })).toEqual(
+            expect.objectContaining({ minimumFractionDigits: 2, maximumFractionDigits: 5 })
+          )
         })
 
         it('should ignore the custom precision if the locale does not support decimal digits', () => {
@@ -524,6 +528,33 @@ describe('NumberFormat', () => {
               currency: 'EUR'
             }).format(1234.5789, { minimumFractionDigits: 4 })
           ).toBe('€1,234.5789')
+
+          expect(
+            new NumberFormat({
+              formatStyle: NumberFormatStyle.Currency,
+              locale: 'en',
+              currency: 'EUR',
+              precision: 3
+            }).format(1234.5789)
+          ).toBe('€1,234.579')
+
+          expect(
+            new NumberFormat({
+              formatStyle: NumberFormatStyle.Currency,
+              locale: 'en',
+              currency: 'EUR',
+              precision: { min: 2, max: 5 }
+            }).format(1234.56789)
+          ).toBe('€1,234.56789')
+
+          expect(
+            new NumberFormat({
+              formatStyle: NumberFormatStyle.Currency,
+              locale: 'en',
+              currency: 'EUR',
+              precision: { min: 2, max: 5 }
+            }).format(1234.5)
+          ).toBe('€1,234.50')
         })
       })
     })


### PR DESCRIPTION
Original issue: https://github.com/dm4t2/intl-number-input/issues/3

This basically reverts the changes from https://github.com/dm4t2/vue-currency-input/commit/887f30c0e529a3d632ab20582d4f359bee2a1420#diff-29cfda01fd63d76489aae8c49e2124d57b0b4597e2a425339c73a4b6c40a7a99 and adds tests.